### PR TITLE
remove cgal dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ SET(CMAKE_BUILD_TYPE Release)
 
 # Libigl
 include(libigl)
-igl_include(copyleft/cgal)
 
 file(GLOB SRCFILES "${PROJECT_SOURCE_DIR}/*.cpp")
 
@@ -18,4 +17,4 @@ add_executable(${PROJECT_NAME}
   src/bisector_of_two_points.cpp
   src/gettimeofday.cpp)
 
-target_link_libraries(${PROJECT_NAME} igl::core igl_copyleft::cgal)
+target_link_libraries(${PROJECT_NAME} igl::core)

--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -6,6 +6,6 @@ include(FetchContent)
 FetchContent_Declare(
     libigl
     GIT_REPOSITORY https://github.com/libigl/libigl.git
-    GIT_TAG v2.4.0
+    GIT_TAG v2.5.0
 )
 FetchContent_MakeAvailable(libigl)

--- a/main.cpp
+++ b/main.cpp
@@ -12,12 +12,7 @@
 // libigl includes
 #include <igl/readOBJ.h>
 #include <igl/AABB.h>
-#include <igl/copyleft/cgal/point_mesh_squared_distance.h>
 #include <igl/writeOBJ.h>
-
-// CGAL includes
-#include <CGAL/Simple_cartesian.h>
-#include <igl/copyleft/cgal/CGAL_includes.hpp>
 
 // Pompeiu-Hausdorff distance includes
 #include "src/upper_bounds.h"

--- a/src/kang_upper_bound.h
+++ b/src/kang_upper_bound.h
@@ -17,8 +17,6 @@
 #include <cfloat>
 #include <Eigen/Core>
 #include <Eigen/Dense>
-#include <CGAL/Simple_cartesian.h>
-#include <CGAL/squared_distance_3.h>
 #include "kang_intersect_edge_and_bisector.h"
 
 


### PR DESCRIPTION
Hi Leo,
I noticed that cgal is only used for double precision point-triangle distance (`CGAL::squared_distance` with `CGAL::SimpleCartesian<double>`). This is not particularly accurate or fast and CGAL is a heavy dependency with a restrictive license. This PR trivially replaces it with libigl's `igl::point_simplex_squared_distance`. Admittedly it seems a bit slower, but I think this is acceptable given the dependency improvement. (It could also be seriously optimized; and it's easier to approach that with CGAL factored out).

I also propose that the code is released under MPL2 (like eigen and libigl), now that CGAL is not needed there's no reason to keep the restrictive GPL license if you don't want. 